### PR TITLE
Refactor to use URL and query parsers/formatters

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@types/base-64": "^0.1.2",
     "@types/jasmine": "^2.6.0",
+    "@types/node": "^8.0.41",
     "jasmine": "^2.8.0",
     "prettier": "^1.7.4",
     "tslint": "^5.7.0",

--- a/spec/spec.ts
+++ b/spec/spec.ts
@@ -186,5 +186,17 @@ describe('imgix-trackable', function() {
       expect(tracklableObject.label).toEqual(undefined);
       expect(tracklableObject.property).toEqual(undefined);
     });
+
+    it('given a URL without a tracking param, it splits the URL back into its tracking components', () => {
+      const url = 'https://images.unsplash.com/photo-123?w=200&h=300';
+
+      const tracklableObject = decode(url);
+
+      expect(tracklableObject.url).toEqual('https://images.unsplash.com/photo-123?w=200&h=300');
+      expect(tracklableObject.app).toEqual(undefined);
+      expect(tracklableObject.page).toEqual(undefined);
+      expect(tracklableObject.label).toEqual(undefined);
+      expect(tracklableObject.property).toEqual(undefined);
+    });
   });
 });

--- a/spec/spec.ts
+++ b/spec/spec.ts
@@ -7,25 +7,25 @@ describe('imgix-trackable', function() {
     it('', () => {
       const url = 'https://images.unsplash.com/photo-123?w=200&ixid=asdkasdkahsdhasd==&dog=true';
 
-      expect(findTrackingParamsInUrl(url)).toEqual('ixid=asdkasdkahsdhasd==');
+      expect(findTrackingParamsInUrl(url)).toEqual('asdkasdkahsdhasd==');
     });
 
     it('', () => {
       const url = 'https://images.unsplash.com/photo-123?w=200&ixid=asdkasdkahsdhasd==';
 
-      expect(findTrackingParamsInUrl(url)).toEqual('ixid=asdkasdkahsdhasd==');
+      expect(findTrackingParamsInUrl(url)).toEqual('asdkasdkahsdhasd==');
     });
 
     it('', () => {
       const url = 'https://images.unsplash.com/photo-123?ixid=asdkasdkahsdhasd==&w=200';
 
-      expect(findTrackingParamsInUrl(url)).toEqual('ixid=asdkasdkahsdhasd==');
+      expect(findTrackingParamsInUrl(url)).toEqual('asdkasdkahsdhasd==');
     });
 
     it('', () => {
       const url = 'https://images.unsplash.com/photo-123?ixid=asdkasdkahsdhasd==';
 
-      expect(findTrackingParamsInUrl(url)).toEqual('ixid=asdkasdkahsdhasd==');
+      expect(findTrackingParamsInUrl(url)).toEqual('asdkasdkahsdhasd==');
     });
 
     it('', () => {
@@ -37,7 +37,7 @@ describe('imgix-trackable', function() {
     it('', () => {
       const url = 'https://images.unsplash.com/photo-123?w=200&ixid=&dog=true';
 
-      expect(findTrackingParamsInUrl(url)).toEqual('ixid=');
+      expect(findTrackingParamsInUrl(url)).toEqual('');
     });
   });
 

--- a/spec/spec.ts
+++ b/spec/spec.ts
@@ -31,7 +31,7 @@ describe('imgix-trackable', function() {
     it('', () => {
       const url = 'https://images.unsplash.com/photo-123?w=200';
 
-      expect(findTrackingParamsInUrl(url)).toEqual('');
+      expect(findTrackingParamsInUrl(url)).toEqual(undefined);
     });
 
     it('', () => {

--- a/spec/tsconfig.json
+++ b/spec/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": ["@types/jasmine"]
+    "types": [
+      "@types/jasmine",
+      "@types/node"
+    ]
   },
   "files": [
     "./spec.ts"

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -13,11 +13,10 @@ export const omit = <T>(key: string, obj: Record<string, T>): Record<string, T> 
   return copy;
 };
 
-export const set = <T>(key: string, value: T, obj: Record<string, T>): Record<string, T> => {
-  const copy = { ...obj };
-  copy[key] = value;
-  return copy;
-};
+export const set = <T>(key: string, value: T, obj: Record<string, T>): Record<string, T> => ({
+  ...obj,
+  [key]: value,
+});
 
 export const identity = <T>(t: T) => t;
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,21 @@
+export const emptyStringToUndefined = (str: string): string | undefined => (str === '' ? undefined : str);
+
+// TS doesn't return the correct type for array and object index signatures. It returns `T` instead
+// of `T | undefined`. These helpers give us the correct type.
+// https://github.com/Microsoft/TypeScript/issues/13778
+export const getIndex = <X>(index: number, xs: X[]): X | undefined => xs[index];
+export const getKey = <X>(index: string, xs: { [key: string]: X }): X | undefined => xs[index];
+
+export const omit = <T>(key: string, obj: Record<string, T>): Record<string, T> => {
+  const copy = { ...obj };
+  delete copy[key];
+  return copy;
+};
+
+export const set = <T>(key: string, value: T, obj: Record<string, T>): Record<string, T> => {
+  const copy = { ...obj };
+  copy[key] = value;
+  return copy;
+};
+
+export const identity = <T>(t: T) => t;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,5 @@
-export const emptyStringToUndefined = (str: string): string | undefined => (str === '' ? undefined : str);
+export const emptyStringToUndefined = (str: string): string | undefined =>
+  str === '' ? undefined : str;
 
 // TS doesn't return the correct type for array and object index signatures. It returns `T` instead
 // of `T | undefined`. These helpers give us the correct type.

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -19,3 +19,10 @@ export const set = <T>(key: string, value: T, obj: Record<string, T>): Record<st
 };
 
 export const identity = <T>(t: T) => t;
+
+export const getValues = <V>(obj: Record<string, V>): V[] =>
+  Object.keys(obj).reduce((acc, key) => {
+    const maybeValue = getKey(key, obj);
+    const value = maybeValue!;
+    return [...acc, value];
+  }, []);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,9 @@ import queryStringHelpers = require('querystring');
 import urlHelpers = require('url');
 
 const emptyStringToUndefined = (str: string): string | undefined => (str === '' ? undefined : str);
+
+// TS doesn't return the correct type for array and object index signatures. It returns `T` instead
+// of `T | undefined`. These helpers give us the correct type.
 const getIndex = <X>(index: number, xs: X[]): X | undefined => xs[index];
 const getKey = <X>(index: string, xs: { [key: string]: X }): X | undefined => xs[index];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,9 +22,10 @@ const getQueryStringFromUrl = (str: string): Maybe<string> =>
     // We cast here to workaround Node typings which incorrectly specify any
     urlHelpers.parse(str).query as null | string,
   );
-const parseQueryString = (str: string): Record<string, string> =>
+type Query = Record<string, string>;
+const parseQueryString = (str: string): Query =>
   // We cast here to workaround Node typings which incorrectly specify any
-  queryStringHelpers.parse(str) as Record<string, string>;
+  queryStringHelpers.parse(str) as Query;
 
 export const _findTrackingParamsInUrl = (url: string): Maybe<string> => {
   const maybeQueryString = getQueryStringFromUrl(url);

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,10 +108,10 @@ const encodeTrackingOptions = (...args: (string | undefined)[]) =>
 
 type TrackingObject = {
   url: string;
-  app: string;
-  page: string;
-  label: string;
-  property: string;
+  app?: string;
+  page?: string;
+  label?: string;
+  property?: string;
 };
 
 const buildTrackingObject = ({ url, app, page, label, property }: Partial<TrackingObject>) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import base64 = require('base-64');
+import queryStringHelpers = require('querystring');
 import urlHelpers = require('url');
 
 import { emptyStringToUndefined, getIndex, getKey, getValues, identity } from './helpers';
@@ -6,7 +7,6 @@ import { mapMaybe, Maybe } from './maybe';
 import {
   getQueryStringFromParsedUrl,
   omitQueryParamFromUrl,
-  parseQueryString,
   Query,
   QueryOptions,
   setQueryParamForUrl,
@@ -20,7 +20,10 @@ const getTrackingQueryParam = (query: Query): Maybe<string> =>
 export const _findTrackingParamsInUrl = (url: string): Maybe<string> => {
   const parsedUrl = urlHelpers.parse(url);
   const maybeQueryString = getQueryStringFromParsedUrl(parsedUrl);
-  const maybeQuery = mapMaybe(parseQueryString({ decodeURIComponent: identity }), maybeQueryString);
+  const maybeQuery = mapMaybe(
+    str => queryStringHelpers.parse(str, undefined, undefined, { decodeURIComponent: identity }),
+    maybeQueryString,
+  );
   return mapMaybe(getTrackingQueryParam, maybeQuery);
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,24 +71,21 @@ const mapQueryForUrl = (
 
 const identity = <T>(t: T) => t;
 
+const omitParamFromUrl = (
+  param: string,
+  queryStringifyOptions: queryStringHelpers.StringifyOptions,
+) => (url: string): string =>
+  mapQueryForUrl(query => omit(param, query), queryStringifyOptions)(url);
+
+const setParamForUrl = (
+  param: string,
+  queryStringifyOptions: queryStringHelpers.StringifyOptions,
+) => (value: string) => (url: string): string =>
+  mapQueryForUrl(query => set(param, value, query), queryStringifyOptions)(url);
+
 //
 // End generic helpers
 //
-
-// 1. Opt-out of URI encoding of query param values. imgix requires Base64 encoding, and we handle
-//    this prior to this function call.
-
-const omitParamFromUrl = (param: string) => (url: string): string =>
-  mapQueryForUrl(query => omit(param, query), {
-    // [1]
-    encodeURIComponent: identity,
-  })(url);
-
-const setParamForUrl = (param: string) => (value: string) => (url: string): string =>
-  mapQueryForUrl(query => set(param, value, query), {
-    // [1]
-    encodeURIComponent: identity,
-  })(url);
 
 export const _findTrackingParamsInUrl = (url: string): Maybe<string> => {
   const parsedUrl = urlHelpers.parse(url);
@@ -97,9 +94,18 @@ export const _findTrackingParamsInUrl = (url: string): Maybe<string> => {
   return mapMaybe(getTrackingQueryParam, maybeQuery);
 };
 
-const omitTrackingParamFromUrl = omitParamFromUrl(TRACKING_PARAM);
+// 1. Opt-out of URI encoding of query param values. imgix requires Base64 encoding, and we handle
+//    this prior to this function call.
 
-const setTrackingParamForUrl = setParamForUrl(TRACKING_PARAM);
+const omitTrackingParamFromUrl = omitParamFromUrl(TRACKING_PARAM, {
+  // [1]
+  encodeURIComponent: identity,
+});
+
+const setTrackingParamForUrl = setParamForUrl(TRACKING_PARAM, {
+  // [1]
+  encodeURIComponent: identity,
+});
 
 const sanitize = (str: string | undefined) => {
   if (str === undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ const omitParamFromUrl = (param: string) => (url: string): string =>
     encodeURIComponent: identity,
   })(url);
 
-const setParamForUrl = (param: string, value: string) => (url: string): string =>
+const setParamForUrl = (param: string) => (value: string) => (url: string): string =>
   mapQueryForUrl(query => set(param, value, query), {
     // [1]
     encodeURIComponent: identity,
@@ -95,6 +95,8 @@ export const _findTrackingParamsInUrl = (url: string): Maybe<string> => {
 };
 
 const omitTrackingParamFromUrl = omitParamFromUrl(TRACKING_PARAM);
+
+const setTrackingParamForUrl = setParamForUrl(TRACKING_PARAM);
 
 const sanitize = (str: string | undefined) => {
   if (str === undefined) {
@@ -122,7 +124,7 @@ export const track = (baseUrl: string, options: Partial<TrackingObject> = {}) =>
   const { app, page, label, property } = options;
 
   const newTrackingParams = encodeTrackingOptions(app, page, label, property);
-  return setParamForUrl(TRACKING_PARAM, newTrackingParams)(baseUrl);
+  return setTrackingParamForUrl(newTrackingParams)(baseUrl);
 };
 
 export const decode = (originalUrl: string): TrackingObject => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,11 +26,12 @@ type Query = Record<string, string>;
 const parseQueryString = (str: string): Query =>
   // We cast here to workaround Node typings which incorrectly specify any
   queryStringHelpers.parse(str) as Query;
+const getTrackingQueryParam = (query: Query) => getKey(TRACKING_PARAM, query);
 
 export const _findTrackingParamsInUrl = (url: string): Maybe<string> => {
   const maybeQueryString = getQueryStringFromUrl(url);
   const maybeQuery = mapMaybe(parseQueryString, maybeQueryString);
-  return mapMaybe(query => getKey(TRACKING_PARAM, query), maybeQuery);
+  return mapMaybe(getTrackingQueryParam, maybeQuery);
 };
 
 const sanitize = (str: string | undefined) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,10 @@ import {
 const TRACKING_PARAM = 'ixid';
 
 const getTrackingQueryParam = (query: Query): Maybe<string> =>
-  mapMaybe(x => (typeof x === 'string' ? x : getIndex(0, x)), getKey(TRACKING_PARAM, query));
+  mapMaybe(
+    queryValue => (typeof queryValue === 'string' ? queryValue : getIndex(0, queryValue)),
+    getKey(TRACKING_PARAM, query),
+  );
 
 export const _findTrackingParamsInUrl = (url: string): Maybe<string> => {
   const parsedUrl = urlHelpers.parse(url);

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ export const track = (baseUrl: string, options: Partial<TrackingObject> = {}) =>
     const hasParams = baseUrl.split('?').length >= 2;
     const joinOperator = hasParams ? '&' : '?';
 
-    return baseUrl + joinOperator + `${TRACKING_PARAM}=${newTrackingParams}`;
+    return `${baseUrl}${joinOperator}${TRACKING_PARAM}=${newTrackingParams}`;
   }
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,6 @@ const emptyStringToUndefined = (str: string): string | undefined => (str === '' 
 const getIndex = <X>(index: number, xs: X[]): X | undefined => xs[index];
 const getKey = <X>(index: string, xs: { [key: string]: X }): X | undefined => xs[index];
 
-const TRACKING_PARAM = 'ixid';
-
 const getQueryStringFromParsedUrl = (parsedUrl: urlHelpers.Url): Maybe<string> =>
   normalizeMaybe(
     // We cast here to workaround Node typings which incorrectly specify any
@@ -22,7 +20,6 @@ type Query = Record<string, string>;
 const parseQueryString = (str: string): Query =>
   // We cast here to workaround Node typings which incorrectly specify any
   queryStringHelpers.parse(str) as Query;
-const getTrackingQueryParam = (query: Query) => getKey(TRACKING_PARAM, query);
 
 const omit = <T>(key: string, obj: Record<string, T>): Record<string, T> => {
   const copy = { ...obj };
@@ -76,6 +73,10 @@ const setQueryParamForUrl = (
 //
 // End generic helpers
 //
+
+const TRACKING_PARAM = 'ixid';
+
+const getTrackingQueryParam = (query: Query) => getKey(TRACKING_PARAM, query);
 
 export const _findTrackingParamsInUrl = (url: string): Maybe<string> => {
   const parsedUrl = urlHelpers.parse(url);

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,13 +61,13 @@ const mapQueryForUrl = (
 
 const identity = <T>(t: T) => t;
 
-const omitParamFromUrl = (
+const omitQueryParamFromUrl = (
   param: string,
   queryStringifyOptions: queryStringHelpers.StringifyOptions,
 ) => (url: string): string =>
   mapQueryForUrl(query => omit(param, query), queryStringifyOptions)(url);
 
-const setParamForUrl = (
+const setQueryParamForUrl = (
   param: string,
   queryStringifyOptions: queryStringHelpers.StringifyOptions,
 ) => (value: string) => (url: string): string =>
@@ -87,12 +87,12 @@ export const _findTrackingParamsInUrl = (url: string): Maybe<string> => {
 // 1. Opt-out of URI encoding of query param values. imgix requires Base64 encoding, and we handle
 //    this prior to this function call.
 
-const omitTrackingParamFromUrl = omitParamFromUrl(TRACKING_PARAM, {
+const omitTrackingParamFromUrl = omitQueryParamFromUrl(TRACKING_PARAM, {
   // [1]
   encodeURIComponent: identity,
 });
 
-const setTrackingParamForUrl = setParamForUrl(TRACKING_PARAM, {
+const setTrackingParamForUrl = setQueryParamForUrl(TRACKING_PARAM, {
   // [1]
   encodeURIComponent: identity,
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,22 +22,36 @@ const getTrackingQueryParam = (query: Query) => getKey(TRACKING_PARAM, query);
 export const _findTrackingParamsInUrl = (url: string): Maybe<string> => {
   const parsedUrl = urlHelpers.parse(url);
   const maybeQueryString = getQueryStringFromParsedUrl(parsedUrl);
-  const maybeQuery = mapMaybe(parseQueryString, maybeQueryString);
+  const maybeQuery = mapMaybe(parseQueryString({ decodeURIComponent: identity }), maybeQueryString);
   return mapMaybe(getTrackingQueryParam, maybeQuery);
 };
 
 // 1. Opt-out of URI encoding of query param values. imgix requires Base64 encoding, and we handle
 //    this prior to this function call.
 
-const omitTrackingParamFromUrl = omitQueryParamFromUrl(TRACKING_PARAM, {
-  // [1]
-  encodeURIComponent: identity,
-});
+const omitTrackingParamFromUrl = omitQueryParamFromUrl(
+  TRACKING_PARAM,
+  {
+    // [1]
+    encodeURIComponent: identity,
+  },
+  {
+    // [1]
+    decodeURIComponent: identity,
+  },
+);
 
-const setTrackingParamForUrl = setQueryParamForUrl(TRACKING_PARAM, {
-  // [1]
-  encodeURIComponent: identity,
-});
+const setTrackingParamForUrl = setQueryParamForUrl(
+  TRACKING_PARAM,
+  {
+    // [1]
+    encodeURIComponent: identity,
+  },
+  {
+    // [1]
+    decodeURIComponent: identity,
+  },
+);
 
 const sanitize = (str: string | undefined) => {
   if (str === undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,13 +31,6 @@ const parseQueryString = (str: string): Query =>
   queryStringHelpers.parse(str) as Query;
 const getTrackingQueryParam = (query: Query) => getKey(TRACKING_PARAM, query);
 
-export const _findTrackingParamsInUrl = (url: string): Maybe<string> => {
-  const parsedUrl = urlHelpers.parse(url);
-  const maybeQueryString = getQueryStringFromParsedUrl(parsedUrl);
-  const maybeQuery = mapMaybe(parseQueryString, maybeQueryString);
-  return mapMaybe(getTrackingQueryParam, maybeQuery);
-};
-
 const omit = <T>(key: string, obj: Record<string, T>): Record<string, T> => {
   const copy = { ...obj };
   delete copy[key];
@@ -75,6 +68,10 @@ const mapQueryForUrl = (
 
 const identity = <T>(t: T) => t;
 
+//
+// End generic helpers
+//
+
 // 1. Opt-out of URI encoding of query param values. imgix requires Base64 encoding, and we handle
 //    this prior to this function call.
 
@@ -89,6 +86,13 @@ const setParamForUrl = (param: string, value: string) => (url: string): string =
     // [1]
     encodeURIComponent: identity,
   })(url);
+
+export const _findTrackingParamsInUrl = (url: string): Maybe<string> => {
+  const parsedUrl = urlHelpers.parse(url);
+  const maybeQueryString = getQueryStringFromParsedUrl(parsedUrl);
+  const maybeQuery = mapMaybe(parseQueryString, maybeQueryString);
+  return mapMaybe(getTrackingQueryParam, maybeQuery);
+};
 
 const omitTrackingParamFromUrl = omitParamFromUrl(TRACKING_PARAM);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,10 +12,6 @@ import {
   setQueryParamForUrl,
 } from './url-query';
 
-//
-// End generic helpers
-//
-
 const TRACKING_PARAM = 'ixid';
 
 const getTrackingQueryParam = (query: Query) => getKey(TRACKING_PARAM, query);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import base64 = require('base-64');
 import queryStringHelpers = require('querystring');
 import urlHelpers = require('url');
 
+const emptyStringToUndefined = (str: string): string | undefined => (str === '' ? undefined : str);
+const getIndex = <X>(index: number, xs: X[]): X | undefined => xs[index];
 const getKey = <X>(index: string, xs: { [key: string]: X }): X | undefined => xs[index];
 
 type Maybe<T> = undefined | T;
@@ -88,8 +90,6 @@ export const track = (baseUrl: string, options: Partial<TrackingObject> = {}) =>
   }
 };
 
-const emptyStringToUndefined = (str: string): string | undefined => str === '' ? undefined : str;
-
 export const decode = (originalUrl: string) => {
   const trackingParams = _findTrackingParamsInUrl(originalUrl);
 
@@ -101,10 +101,10 @@ export const decode = (originalUrl: string) => {
   const decodedValues = base64.decode(encodedValues);
   const values = decodedValues.split(';');
 
-  const app = values[0];
-  const page = emptyStringToUndefined(values[1]);
-  const label = emptyStringToUndefined(values[2]);
-  const property = emptyStringToUndefined(values[3]);
+  const app = getIndex(0, values);
+  const page = mapMaybe(emptyStringToUndefined, getIndex(1, values));
+  const label = mapMaybe(emptyStringToUndefined, getIndex(2, values));
+  const property = mapMaybe(emptyStringToUndefined, getIndex(3, values));
 
   return buildTrackingObject({
     url: originalUrl.replace(new RegExp(`.${TRACKING_PARAM}=${trackingParams}`), ''),

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   omitQueryParamFromUrl,
   parseQueryString,
   Query,
+  QueryOptions,
   setQueryParamForUrl,
 } from './url-query';
 
@@ -29,29 +30,20 @@ export const _findTrackingParamsInUrl = (url: string): Maybe<string> => {
 // 1. Opt-out of URI encoding of query param values. imgix requires Base64 encoding, and we handle
 //    this prior to this function call.
 
-const omitTrackingParamFromUrl = omitQueryParamFromUrl(
-  TRACKING_PARAM,
-  {
+const queryOptions: QueryOptions = {
+  queryStringifyOptions: {
     // [1]
     encodeURIComponent: identity,
   },
-  {
+  queryParseOptions: {
     // [1]
     decodeURIComponent: identity,
   },
-);
+};
 
-const setTrackingParamForUrl = setQueryParamForUrl(
-  TRACKING_PARAM,
-  {
-    // [1]
-    encodeURIComponent: identity,
-  },
-  {
-    // [1]
-    decodeURIComponent: identity,
-  },
-);
+const omitTrackingParamFromUrl = omitQueryParamFromUrl(TRACKING_PARAM, queryOptions);
+
+const setTrackingParamForUrl = setQueryParamForUrl(TRACKING_PARAM, queryOptions);
 
 const sanitize = (str: string | undefined) => {
   if (str === undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,13 +141,14 @@ export const decode = (originalUrl: string) => {
   const decodedValues = base64.decode(encodedValues);
   const values = decodedValues.split(';');
 
+  const url = omitTrackingParamFromUrl(originalUrl);
   const app = getIndex(0, values);
   const page = mapMaybe(emptyStringToUndefined, getIndex(1, values));
   const label = mapMaybe(emptyStringToUndefined, getIndex(2, values));
   const property = mapMaybe(emptyStringToUndefined, getIndex(3, values));
 
   return buildTrackingObject({
-    url: omitTrackingParamFromUrl(originalUrl),
+    url,
     app,
     page,
     label,

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,15 +59,18 @@ const sanitize = (str: string | undefined) => {
 const encodeTrackingOptions = (...args: (string | undefined)[]) =>
   base64.encode(`${args.map(sanitize).join(';')};`);
 
-type TrackingObject = {
-  url: string;
+type TrackingObjectParams = {
   app?: string;
   page?: string;
   label?: string;
   property?: string;
 };
 
-export const track = (baseUrl: string, options: Partial<TrackingObject> = {}) => {
+type TrackingObject = {
+  url: string;
+} & TrackingObjectParams;
+
+export const track = (baseUrl: string, options: TrackingObjectParams = {}) => {
   const { app, page, label, property } = options;
 
   const newTrackingParams = encodeTrackingOptions(app, page, label, property);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,24 +2,14 @@ import base64 = require('base-64');
 import queryStringHelpers = require('querystring');
 import urlHelpers = require('url');
 
+import { getOrElseMaybe, mapMaybe, Maybe, normalizeMaybe } from './maybe';
+
 const emptyStringToUndefined = (str: string): string | undefined => (str === '' ? undefined : str);
 
 // TS doesn't return the correct type for array and object index signatures. It returns `T` instead
 // of `T | undefined`. These helpers give us the correct type.
 const getIndex = <X>(index: number, xs: X[]): X | undefined => xs[index];
 const getKey = <X>(index: string, xs: { [key: string]: X }): X | undefined => xs[index];
-
-type Maybe<T> = undefined | T;
-
-const isMaybeDefined = <T>(maybeT: Maybe<T>): maybeT is T => maybeT !== undefined;
-
-const mapMaybe = <T, B>(f: (t: T) => B, maybeT: Maybe<T>): Maybe<B> =>
-  isMaybeDefined(maybeT) ? f(maybeT) : maybeT;
-
-const getOrElseMaybe = <T>(f: () => T, maybeT: Maybe<T>): T =>
-  isMaybeDefined(maybeT) ? maybeT : f();
-
-const normalizeMaybe = <T>(nullMaybe: T | null) => (nullMaybe === null ? undefined : nullMaybe);
 
 const TRACKING_PARAM = 'ixid';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,15 +114,6 @@ type TrackingObject = {
   property?: string;
 };
 
-const buildTrackingObject = ({ url, app, page, label, property }: Partial<TrackingObject>) =>
-  ({
-    url,
-    app,
-    page,
-    label,
-    property,
-  });
-
 export const track = (baseUrl: string, options: Partial<TrackingObject> = {}) => {
   const { app, page, label, property } = options;
 
@@ -130,11 +121,11 @@ export const track = (baseUrl: string, options: Partial<TrackingObject> = {}) =>
   return setParamForUrl(TRACKING_PARAM, newTrackingParams)(baseUrl);
 };
 
-export const decode = (originalUrl: string) => {
+export const decode = (originalUrl: string): TrackingObject => {
   const trackingParams = _findTrackingParamsInUrl(originalUrl);
 
   if (trackingParams === undefined) {
-    return buildTrackingObject({ url: originalUrl });
+    return { url: originalUrl };
   }
 
   const encodedValues = trackingParams;
@@ -147,11 +138,11 @@ export const decode = (originalUrl: string) => {
   const label = mapMaybe(emptyStringToUndefined, getIndex(2, values));
   const property = mapMaybe(emptyStringToUndefined, getIndex(3, values));
 
-  return buildTrackingObject({
+  return {
     url,
     app,
     page,
     label,
     property,
-  });
+  };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,8 @@ import {
 
 const TRACKING_PARAM = 'ixid';
 
-const getTrackingQueryParam = (query: Query) => getKey(TRACKING_PARAM, query);
+const getTrackingQueryParam = (query: Query): Maybe<string> =>
+  mapMaybe(x => (typeof x === 'string' ? x : getIndex(0, x)), getKey(TRACKING_PARAM, query));
 
 export const _findTrackingParamsInUrl = (url: string): Maybe<string> => {
   const parsedUrl = urlHelpers.parse(url);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import base64 = require('base-64');
 import urlHelpers = require('url');
 
-import { emptyStringToUndefined, getIndex, getKey, identity } from './helpers';
+import { emptyStringToUndefined, getIndex, getKey, getValues, identity } from './helpers';
 import { mapMaybe, Maybe } from './maybe';
 import {
   getQueryStringFromParsedUrl,
@@ -56,8 +56,12 @@ const sanitize = (str: string | undefined) => {
     .toLowerCase();
 };
 
-const encodeTrackingOptions = (...args: (string | undefined)[]) =>
-  base64.encode(`${args.map(sanitize).join(';')};`);
+const encodeTrackingOptions = (options: TrackingObjectParams) =>
+  base64.encode(
+    `${getValues(options)
+      .map(sanitize)
+      .join(';')};`,
+  );
 
 type TrackingObjectParams = {
   app?: string;
@@ -70,10 +74,8 @@ type TrackingObject = {
   url: string;
 } & TrackingObjectParams;
 
-export const track = (baseUrl: string, options: TrackingObjectParams = {}) => {
-  const { app, page, label, property } = options;
-
-  const newTrackingParams = encodeTrackingOptions(app, page, label, property);
+export const track = (baseUrl: string, options: TrackingObjectParams) => {
+  const newTrackingParams = encodeTrackingOptions(options);
   return setTrackingParamForUrl(newTrackingParams)(baseUrl);
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,10 +32,7 @@ export const _findTrackingParamsInUrl = (url: string): string => {
   const maybeQuery = mapMaybe(parseQueryString, maybeQueryString);
   return getOrElseMaybe(
     () => '',
-    mapMaybe(
-      s => `${TRACKING_PARAM}=${s}`,
-      mapMaybe(query => getKey(TRACKING_PARAM, query), maybeQuery),
-    ),
+    mapMaybe(query => getKey(TRACKING_PARAM, query), maybeQuery),
   );
 };
 
@@ -73,12 +70,12 @@ const buildTrackingObject = ({ url, app, page, label, property }: Partial<Tracki
 export const track = (baseUrl: string, options: Partial<TrackingObject> = {}) => {
   const { app, page, label, property } = options;
 
-  const newTrackingParams = `${TRACKING_PARAM}=${encodeTrackingOptions(
+  const newTrackingParams = encodeTrackingOptions(
     app,
     page,
     label,
     property,
-  )}`;
+  );
   const existingTrackParams = _findTrackingParamsInUrl(baseUrl);
 
   if (existingTrackParams !== '') {
@@ -87,7 +84,7 @@ export const track = (baseUrl: string, options: Partial<TrackingObject> = {}) =>
     const hasParams = baseUrl.split('?').length >= 2;
     const joinOperator = hasParams ? '&' : '?';
 
-    return baseUrl + joinOperator + newTrackingParams;
+    return baseUrl + joinOperator + `${TRACKING_PARAM}=${newTrackingParams}`;
   }
 };
 
@@ -100,7 +97,7 @@ export const decode = (originalUrl: string) => {
     return buildTrackingObject({ url: originalUrl });
   }
 
-  const encodedValues = trackingParams.split(`${TRACKING_PARAM}=`)[1];
+  const encodedValues = trackingParams;
   const decodedValues = base64.decode(encodedValues);
   const values = decodedValues.split(';');
 
@@ -110,7 +107,7 @@ export const decode = (originalUrl: string) => {
   const property = emptyStringToUndefined(values[3]);
 
   return buildTrackingObject({
-    url: originalUrl.replace(new RegExp(`.${trackingParams}`), ''),
+    url: originalUrl.replace(new RegExp(`.${TRACKING_PARAM}=${trackingParams}`), ''),
     app,
     page,
     label,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,10 +17,10 @@ const normalizeMaybe = <T>(nullMaybe: T | null) => (nullMaybe === null ? undefin
 
 const TRACKING_PARAM = 'ixid';
 
-const getQueryStringFromUrl = (str: string): Maybe<string> =>
+const getQueryStringFromParsedUrl = (parsedUrl: urlHelpers.Url): Maybe<string> =>
   normalizeMaybe(
     // We cast here to workaround Node typings which incorrectly specify any
-    urlHelpers.parse(str).query as null | string,
+    parsedUrl.query as null | string,
   );
 type Query = Record<string, string>;
 const parseQueryString = (str: string): Query =>
@@ -29,7 +29,8 @@ const parseQueryString = (str: string): Query =>
 const getTrackingQueryParam = (query: Query) => getKey(TRACKING_PARAM, query);
 
 export const _findTrackingParamsInUrl = (url: string): Maybe<string> => {
-  const maybeQueryString = getQueryStringFromUrl(url);
+  const parsedUrl = urlHelpers.parse(url);
+  const maybeQueryString = getQueryStringFromParsedUrl(parsedUrl);
   const maybeQuery = mapMaybe(parseQueryString, maybeQueryString);
   return mapMaybe(getTrackingQueryParam, maybeQuery);
 };

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -1,0 +1,12 @@
+export type Maybe<T> = undefined | T;
+
+export const isMaybeDefined = <T>(maybeT: Maybe<T>): maybeT is T => maybeT !== undefined;
+
+export const mapMaybe = <T, B>(f: (t: T) => B, maybeT: Maybe<T>): Maybe<B> =>
+  isMaybeDefined(maybeT) ? f(maybeT) : maybeT;
+
+export const getOrElseMaybe = <T>(f: () => T, maybeT: Maybe<T>): T =>
+  isMaybeDefined(maybeT) ? maybeT : f();
+
+export const normalizeMaybe = <T>(nullMaybe: T | null) =>
+  nullMaybe === null ? undefined : nullMaybe;

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": ["@types/base-64"]
+    "types": [
+      "@types/base-64",
+      "@types/node"
+    ]
   },
   "files": [
     "./index.ts"

--- a/src/url-query.ts
+++ b/src/url-query.ts
@@ -1,4 +1,4 @@
-import queryStringHelpers = require('querystring');
+import * as queryStringHelpers from 'querystring';
 import * as urlHelpers from 'url';
 
 import { omit, set } from './helpers';

--- a/src/url-query.ts
+++ b/src/url-query.ts
@@ -25,10 +25,9 @@ export const parseQueryString = (queryParseOptions: queryStringHelpers.ParseOpti
   // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/20651
   queryStringHelpers.parse(str, undefined, undefined, queryParseOptions) as Query;
 
-export const mapQueryForUrl = (
-  fn: (query: Query) => Query,
-  queryOptions: QueryOptions,
-) => (url: string) => {
+export const mapQueryForUrl = (fn: (query: Query) => Query, queryOptions: QueryOptions) => (
+  url: string,
+) => {
   const { queryParseOptions, queryStringifyOptions } = queryOptions;
 
   const parsedUrl = urlHelpers.parse(url);
@@ -53,13 +52,10 @@ export const mapQueryForUrl = (
   return newUrl;
 };
 
-export const omitQueryParamFromUrl = (
-  param: string,
-  queryOptions: QueryOptions,
-) => (url: string): string => mapQueryForUrl(query => omit(param, query), queryOptions)(url);
+export const omitQueryParamFromUrl = (param: string, queryOptions: QueryOptions) => (
+  url: string,
+): string => mapQueryForUrl(query => omit(param, query), queryOptions)(url);
 
-export const setQueryParamForUrl = (
-  param: string,
-  queryOptions: QueryOptions,
-) => (value: string) => (url: string): string =>
-  mapQueryForUrl(query => set(param, value, query), queryOptions)(url);
+export const setQueryParamForUrl = (param: string, queryOptions: QueryOptions) => (
+  value: string,
+) => (url: string): string => mapQueryForUrl(query => set(param, value, query), queryOptions)(url);

--- a/src/url-query.ts
+++ b/src/url-query.ts
@@ -1,0 +1,52 @@
+import queryStringHelpers = require('querystring');
+import urlHelpers = require('url');
+
+import { omit, set } from './helpers';
+import { getOrElseMaybe, mapMaybe, Maybe, normalizeMaybe } from './maybe';
+
+export const getQueryStringFromParsedUrl = (parsedUrl: urlHelpers.Url): Maybe<string> =>
+  normalizeMaybe(
+    // We cast here to workaround Node typings which incorrectly specify any
+    parsedUrl.query as null | string,
+  );
+
+export type Query = Record<string, string>;
+
+export const parseQueryString = (str: string): Query =>
+  // We cast here to workaround Node typings which incorrectly specify any
+  queryStringHelpers.parse(str) as Query;
+
+export const mapQueryForUrl = (
+  fn: (query: Query) => Query,
+  queryStringifyOptions: queryStringHelpers.StringifyOptions,
+) => (url: string) => {
+  const parsedUrl = urlHelpers.parse(url);
+
+  const maybeQueryString = getQueryStringFromParsedUrl(parsedUrl);
+  const query = getOrElseMaybe(() => ({}), mapMaybe(parseQueryString, maybeQueryString));
+
+  const newQuery: Query = fn(query);
+  const newQueryString = queryStringHelpers.stringify(
+    newQuery,
+    undefined,
+    undefined,
+    queryStringifyOptions,
+  );
+
+  const newParsedUrl = { ...parsedUrl, search: newQueryString };
+  const newUrl = urlHelpers.format(newParsedUrl);
+
+  return newUrl;
+};
+
+export const omitQueryParamFromUrl = (
+  param: string,
+  queryStringifyOptions: queryStringHelpers.StringifyOptions,
+) => (url: string): string =>
+  mapQueryForUrl(query => omit(param, query), queryStringifyOptions)(url);
+
+export const setQueryParamForUrl = (
+  param: string,
+  queryStringifyOptions: queryStringHelpers.StringifyOptions,
+) => (value: string) => (url: string): string =>
+  mapQueryForUrl(query => set(param, value, query), queryStringifyOptions)(url);

--- a/src/url-query.ts
+++ b/src/url-query.ts
@@ -11,7 +11,7 @@ export const getQueryStringFromParsedUrl = (parsedUrl: urlHelpers.Url): Maybe<st
     parsedUrl.query as null | string,
   );
 
-export type Query = Record<string, string>;
+export type Query = Record<string, string | string[]>;
 
 export type QueryOptions = {
   queryStringifyOptions: queryStringHelpers.StringifyOptions;

--- a/src/url-query.ts
+++ b/src/url-query.ts
@@ -12,18 +12,24 @@ export const getQueryStringFromParsedUrl = (parsedUrl: urlHelpers.Url): Maybe<st
 
 export type Query = Record<string, string>;
 
-export const parseQueryString = (str: string): Query =>
+export const parseQueryString = (queryParseOptions: queryStringHelpers.ParseOptions) => (
+  str: string,
+): Query =>
   // We cast here to workaround Node typings which incorrectly specify any
-  queryStringHelpers.parse(str) as Query;
+  queryStringHelpers.parse(str, undefined, undefined, queryParseOptions) as Query;
 
 export const mapQueryForUrl = (
   fn: (query: Query) => Query,
   queryStringifyOptions: queryStringHelpers.StringifyOptions,
+  queryParseOptions: queryStringHelpers.ParseOptions,
 ) => (url: string) => {
   const parsedUrl = urlHelpers.parse(url);
 
   const maybeQueryString = getQueryStringFromParsedUrl(parsedUrl);
-  const query = getOrElseMaybe(() => ({}), mapMaybe(parseQueryString, maybeQueryString));
+  const query = getOrElseMaybe(
+    () => ({}),
+    mapMaybe(parseQueryString(queryParseOptions), maybeQueryString),
+  );
 
   const newQuery: Query = fn(query);
   const newQueryString = queryStringHelpers.stringify(
@@ -42,11 +48,13 @@ export const mapQueryForUrl = (
 export const omitQueryParamFromUrl = (
   param: string,
   queryStringifyOptions: queryStringHelpers.StringifyOptions,
+  queryParseOptions: queryStringHelpers.ParseOptions,
 ) => (url: string): string =>
-  mapQueryForUrl(query => omit(param, query), queryStringifyOptions)(url);
+  mapQueryForUrl(query => omit(param, query), queryStringifyOptions, queryParseOptions)(url);
 
 export const setQueryParamForUrl = (
   param: string,
   queryStringifyOptions: queryStringHelpers.StringifyOptions,
+  queryParseOptions: queryStringHelpers.ParseOptions,
 ) => (value: string) => (url: string): string =>
-  mapQueryForUrl(query => set(param, value, query), queryStringifyOptions)(url);
+  mapQueryForUrl(query => set(param, value, query), queryStringifyOptions, queryParseOptions)(url);

--- a/src/url-query.ts
+++ b/src/url-query.ts
@@ -12,6 +12,11 @@ export const getQueryStringFromParsedUrl = (parsedUrl: urlHelpers.Url): Maybe<st
 
 export type Query = Record<string, string>;
 
+export type QueryOptions = {
+  queryStringifyOptions: queryStringHelpers.StringifyOptions;
+  queryParseOptions: queryStringHelpers.ParseOptions;
+};
+
 export const parseQueryString = (queryParseOptions: queryStringHelpers.ParseOptions) => (
   str: string,
 ): Query =>
@@ -20,9 +25,10 @@ export const parseQueryString = (queryParseOptions: queryStringHelpers.ParseOpti
 
 export const mapQueryForUrl = (
   fn: (query: Query) => Query,
-  queryStringifyOptions: queryStringHelpers.StringifyOptions,
-  queryParseOptions: queryStringHelpers.ParseOptions,
+  queryOptions: QueryOptions,
 ) => (url: string) => {
+  const { queryParseOptions, queryStringifyOptions } = queryOptions;
+
   const parsedUrl = urlHelpers.parse(url);
 
   const maybeQueryString = getQueryStringFromParsedUrl(parsedUrl);
@@ -47,14 +53,11 @@ export const mapQueryForUrl = (
 
 export const omitQueryParamFromUrl = (
   param: string,
-  queryStringifyOptions: queryStringHelpers.StringifyOptions,
-  queryParseOptions: queryStringHelpers.ParseOptions,
-) => (url: string): string =>
-  mapQueryForUrl(query => omit(param, query), queryStringifyOptions, queryParseOptions)(url);
+  queryOptions: QueryOptions,
+) => (url: string): string => mapQueryForUrl(query => omit(param, query), queryOptions)(url);
 
 export const setQueryParamForUrl = (
   param: string,
-  queryStringifyOptions: queryStringHelpers.StringifyOptions,
-  queryParseOptions: queryStringHelpers.ParseOptions,
+  queryOptions: QueryOptions,
 ) => (value: string) => (url: string): string =>
-  mapQueryForUrl(query => set(param, value, query), queryStringifyOptions, queryParseOptions)(url);
+  mapQueryForUrl(query => set(param, value, query), queryOptions)(url);

--- a/src/url-query.ts
+++ b/src/url-query.ts
@@ -1,5 +1,5 @@
 import queryStringHelpers = require('querystring');
-import urlHelpers = require('url');
+import * as urlHelpers from 'url';
 
 import { omit, set } from './helpers';
 import { getOrElseMaybe, mapMaybe, Maybe, normalizeMaybe } from './maybe';

--- a/src/url-query.ts
+++ b/src/url-query.ts
@@ -18,13 +18,6 @@ export type QueryOptions = {
   queryParseOptions: queryStringHelpers.ParseOptions;
 };
 
-export const parseQueryString = (queryParseOptions: queryStringHelpers.ParseOptions) => (
-  str: string,
-): Query =>
-  // We cast here to workaround Node typings which incorrectly specify any
-  // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/20651
-  queryStringHelpers.parse(str, undefined, undefined, queryParseOptions) as Query;
-
 export const mapQueryForUrl = (fn: (query: Query) => Query, queryOptions: QueryOptions) => (
   url: string,
 ) => {
@@ -35,7 +28,10 @@ export const mapQueryForUrl = (fn: (query: Query) => Query, queryOptions: QueryO
   const maybeQueryString = getQueryStringFromParsedUrl(parsedUrl);
   const query = getOrElseMaybe(
     () => ({}),
-    mapMaybe(parseQueryString(queryParseOptions), maybeQueryString),
+    mapMaybe(
+      str => queryStringHelpers.parse(str, undefined, undefined, queryParseOptions),
+      maybeQueryString,
+    ),
   );
 
   const newQuery: Query = fn(query);

--- a/src/url-query.ts
+++ b/src/url-query.ts
@@ -7,6 +7,7 @@ import { getOrElseMaybe, mapMaybe, Maybe, normalizeMaybe } from './maybe';
 export const getQueryStringFromParsedUrl = (parsedUrl: urlHelpers.Url): Maybe<string> =>
   normalizeMaybe(
     // We cast here to workaround Node typings which incorrectly specify any
+    // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/20650
     parsedUrl.query as null | string,
   );
 
@@ -21,6 +22,7 @@ export const parseQueryString = (queryParseOptions: queryStringHelpers.ParseOpti
   str: string,
 ): Query =>
   // We cast here to workaround Node typings which incorrectly specify any
+  // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/20651
   queryStringHelpers.parse(str, undefined, undefined, queryParseOptions) as Query;
 
 export const mapQueryForUrl = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,8 +11,8 @@
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.6.0.tgz#997b41a27752b4850af2683bc4a8d8222c25bd02"
 
 "@types/node@^8.0.41":
-  version "8.0.41"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.41.tgz#b88d23b454fdbcfd170f61de88a33ec9cd98960a"
+  version "8.0.45"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.45.tgz#89fad82439d5624e1b5c6b42f0f5d85136dcdecc"
 
 ansi-regex@^2.0.0:
   version "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,10 @@
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.6.0.tgz#997b41a27752b4850af2683bc4a8d8222c25bd02"
 
+"@types/node@^8.0.41":
+  version "8.0.41"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.41.tgz#b88d23b454fdbcfd170f61de88a33ec9cd98960a"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"


### PR DESCRIPTION
Depends on #1 

Refactor to use Node's `url` and `querystring` modules for parsing/formatting the URL and query, instead of regular expressions and string manipulation.

There is more code but it's all generic, e.g. `omitParamFromUrl` and `setParamForUrl`.

See commits for details.